### PR TITLE
Offline mode validation incorrectly rejects --lockout-threshold 0

### DIFF
--- a/conpass/cli.py
+++ b/conpass/cli.py
@@ -189,7 +189,7 @@ def _validate_inputs(
 
     # Check offline mode requirements
     if username is None and user_file:
-        if not lockout_threshold or not lockout_observation_window:
+        if lockout_threshold is None or not lockout_observation_window:
             raise ConfigurationError(
                 "When using --user-file without --username, "
                 "--lockout-threshold and --lockout-observation-window are required"


### PR DESCRIPTION
First of all, great blog post and tool, well done 👏!

While testing ConPass in a lab, I noticed what appears to be a validation issue in offline mode:

<img width="1260" height="39" alt="conpass-flags" src="https://github.com/user-attachments/assets/2e54ce63-62a5-43e9-88f0-c9d2f0605b99" />

The validation currently uses:

```python
if not lockout_threshold or not lockout_observation_window:
```

which causes the value `0` to be treated as missing, while the rest of the codebase appears to explicitly support this case.

After replacing the validation with:

```python
if lockout_threshold is None or not lockout_observation_window:
```

ConPass proceeds as normal.

<img width="1149" height="85" alt="conpass-lockout-threshold-zero" src="https://github.com/user-attachments/assets/9a3e0ae4-5d87-4aa8-ab4b-f542838deda5" />

I initially thought this might be intended behaviour, but while reading the code I noticed that there is logic to handle the `--lockout-threshold=0` case, so I thought it was worth reporting.

If this is not the case and I minterpreted the behaviour, perhaps the validation could reject `0` explicitly with a more descriptive error message.

Looking forward to using the tool more!

**Note:** I only modified the threshold validation because a threshold of `0` appears to be explicitly supported elsewhere in the codebase. I wasn't sure whether an observation window of `0` is intended to be valid as well.