### PR TITLE
Added filtering when a users file is passed.

### DIFF
--- a/conpass/core/worker.py
+++ b/conpass/core/worker.py
@@ -155,9 +155,13 @@ class Worker(threading.Thread):
             if self.debug:
                 self.console.print(f"[cyan]✓ Worker {self.worker_id}: Lock acquired for {user.samaccountname}/{password}[/cyan]")
 
+            before_bad_count = None
+
             # Update user's bad password info from LDAP (if online)
             if self.online_mode and self.ldap_service:
                 self._update_user_from_ldap(user)
+
+                # Capture badPwdCount before authentication attempt
                 before_bad_count = user.get_bad_password_count()
 
             # Check if we can test this password
@@ -296,9 +300,7 @@ class Worker(threading.Thread):
             success = status.is_success
             user.mark_password_tested(password, success, user_status)
 
-            # Detect potential n-1 / n-2 password matches
-            # before_bad_count = None
-
+            # Record passwords that fail authentication without increasing badPwdCount
             if (
                 self.online_mode and
                 self.ldap_service and
@@ -307,30 +309,31 @@ class Worker(threading.Thread):
                 self._update_user_from_ldap(user)
                 after_bad_count = user.get_bad_password_count()
 
-                self.console.print(
-                    f"DEBUG: user={user.samaccountname} "
-                    f"password={password} "
-                    f"status={status} "
-                    f"before={before_bad_count} "
-                    f"after={after_bad_count}"
-                )
-
                 if (
                     before_bad_count is not None and
                     after_bad_count == before_bad_count
                 ):
                     user.add_history_candidate(password)
 
-                    # self.console.print(
-                    #     f"[cyan]Possible password-history match detected: "
-                    #     f"{user.samaccountname}/{password}[/cyan]"
-                    #     )
+                    self.console.print(
+                        f"[yellow]{user.samaccountname} - {password}[/yellow]"
+                        f"[bright_black] (potential history match)[/bright_black]"
+                    )
 
-                    # self.console.print(
-                    #     f"[cyan]🔍 Possible N-2 match: "
-                    #     f"{user.samaccountname}/{password} "
-                    #     f"(badPwdCount remained {before_bad_count})[/cyan]"
-                    # )
+                    if self.debug:
+                        self.console.print(
+                            f"[cyan]History candidate detected: "
+                            f"{user.samaccountname}/{password} "
+                            f"(badPwdCount {before_bad_count} -> {after_bad_count}, "
+                            f"policy={user.policy.name})[/cyan]"
+                        )
+                else:
+                    if self.debug:
+                        self.console.print(
+                            f"[bright_black]Invalid password increased badPwdCount: "
+                            f"{user.samaccountname}/{password} "
+                            f"({before_bad_count} -> {after_bad_count})[/bright_black]"
+                        )
 
             # Record in database if enabled
             if self.database_service:

--- a/conpass/core/worker.py
+++ b/conpass/core/worker.py
@@ -158,6 +158,7 @@ class Worker(threading.Thread):
             # Update user's bad password info from LDAP (if online)
             if self.online_mode and self.ldap_service:
                 self._update_user_from_ldap(user)
+                before_bad_count = user.get_bad_password_count()
 
             # Check if we can test this password
             can_test, reason = user.can_test_password(password)
@@ -294,6 +295,35 @@ class Worker(threading.Thread):
             # Mark password as tested
             success = status.is_success
             user.mark_password_tested(password, success, user_status)
+
+            # Detect potential n-1 / n-2 password matches
+            before_bad_count = None
+
+            if (
+                self.online_mode and
+                self.ldap_service and
+                status == AuthStatus.INVALID_PASSWORD
+            ):
+                self._update_user_from_ldap(user)
+                after_bad_count = user.get_bad_password_count()
+
+                if (
+                    before_bad_count is not None and
+                    after_bad_count == before_bad_count
+                ):
+                    user.add_history_candidate(password)
+
+                    self.console.print(
+                        f"[cyan]Possible password-history match detected: "
+                        f"{user.samaccountname}/{password}[/cyan]"
+                        )
+
+                    if self.debug:
+                        self.console.print(
+                            f"[cyan]🔍 Possible N-2 match: "
+                            f"{user.samaccountname}/{password} "
+                            f"(badPwdCount remained {before_bad_count})[/cyan]"
+                        )
 
             # Record in database if enabled
             if self.database_service:

--- a/conpass/core/worker.py
+++ b/conpass/core/worker.py
@@ -297,7 +297,7 @@ class Worker(threading.Thread):
             user.mark_password_tested(password, success, user_status)
 
             # Detect potential n-1 / n-2 password matches
-            before_bad_count = None
+            # before_bad_count = None
 
             if (
                 self.online_mode and
@@ -307,22 +307,30 @@ class Worker(threading.Thread):
                 self._update_user_from_ldap(user)
                 after_bad_count = user.get_bad_password_count()
 
+                self.console.print(
+                    f"DEBUG: user={user.samaccountname} "
+                    f"password={password} "
+                    f"status={status} "
+                    f"before={before_bad_count} "
+                    f"after={after_bad_count}"
+                )
+
                 if (
                     before_bad_count is not None and
                     after_bad_count == before_bad_count
                 ):
                     user.add_history_candidate(password)
 
-                    self.console.print(
-                        f"[cyan]Possible password-history match detected: "
-                        f"{user.samaccountname}/{password}[/cyan]"
-                        )
+                    # self.console.print(
+                    #     f"[cyan]Possible password-history match detected: "
+                    #     f"{user.samaccountname}/{password}[/cyan]"
+                    #     )
 
-                    self.console.print(
-                        f"[cyan]🔍 Possible N-2 match: "
-                        f"{user.samaccountname}/{password} "
-                        f"(badPwdCount remained {before_bad_count})[/cyan]"
-                    )
+                    # self.console.print(
+                    #     f"[cyan]🔍 Possible N-2 match: "
+                    #     f"{user.samaccountname}/{password} "
+                    #     f"(badPwdCount remained {before_bad_count})[/cyan]"
+                    # )
 
             # Record in database if enabled
             if self.database_service:

--- a/conpass/core/worker.py
+++ b/conpass/core/worker.py
@@ -318,12 +318,11 @@ class Worker(threading.Thread):
                         f"{user.samaccountname}/{password}[/cyan]"
                         )
 
-                    if self.debug:
-                        self.console.print(
-                            f"[cyan]🔍 Possible N-2 match: "
-                            f"{user.samaccountname}/{password} "
-                            f"(badPwdCount remained {before_bad_count})[/cyan]"
-                        )
+                    self.console.print(
+                        f"[cyan]🔍 Possible N-2 match: "
+                        f"{user.samaccountname}/{password} "
+                        f"(badPwdCount remained {before_bad_count})[/cyan]"
+                    )
 
             # Record in database if enabled
             if self.database_service:

--- a/conpass/models/user.py
+++ b/conpass/models/user.py
@@ -54,6 +54,7 @@ class User:
         self._found_password: str | None = None
         self._status = UserStatus.PENDING
         self._is_restricted = False  # Account has restrictions (Protected Users, etc.)
+        self._history_candidates: set[str] = set() # # Potential n-1 / n-2 password history matches
 
     def try_acquire_lock(self, blocking: bool = True, timeout: float = -1) -> bool:
         """
@@ -253,6 +254,16 @@ class User:
         """Get bad password count (thread-safe read)."""
         with self._lock:
             return self._bad_password_count
+
+    def add_history_candidate(self, password: str) -> None:
+        """Record a potential n-1 / n-2 password history match."""
+        with self._lock:
+            self._history_candidates.add(password)
+
+    def get_history_candidates(self) -> list[str]:
+        """Get all potential n-1 / n-2 password history matches."""
+        with self._lock:
+            return sorted(self._history_candidates)
 
     def __str__(self) -> str:
         with self._lock:

--- a/conpass/services/ldap.py
+++ b/conpass/services/ldap.py
@@ -117,8 +117,6 @@ class LdapService:
             Connection object if successful, None otherwise
         """
 
-        print("DEBUG: USING MODIFIED _create_connection") # Debug
-
         # Determine the password to use (cleartext or hash)
         if self.credentials.has_hash:
             # Parse and format hash for LDAP3
@@ -151,7 +149,6 @@ class LdapService:
                 # Fall back to non-SSL
                 if self.debug and self.console:
                     self.console.print(f"[cyan][DEBUG] SSL failed for {dc_ip} ({type(e).__name__}), trying non-SSL[/cyan]")
-                    f"print({e})" # Debug
                 server = self._create_ldap_server(dc_ip, False)
                 # conn = Connection(
                 #     server,
@@ -171,11 +168,6 @@ class LdapService:
                 #         self.console.print(f"[cyan][DEBUG] Non-SSL connection successful to {dc_ip}[/cyan]")
                 #     return conn
                 # return None
-
-                if self.debug and self.console: # debug
-                    self.console.print(
-                        f"[cyan][DEBUG] Attempting non-SSL bind to {dc_ip}[/cyan]"
-                    )
 
                 if conn.bind():
                     if self.debug and self.console:

--- a/conpass/services/ldap.py
+++ b/conpass/services/ldap.py
@@ -153,11 +153,17 @@ class LdapService:
                     self.console.print(f"[cyan][DEBUG] SSL failed for {dc_ip} ({type(e).__name__}), trying non-SSL[/cyan]")
                     f"print({e})" # Debug
                 server = self._create_ldap_server(dc_ip, False)
-                conn = Connection(
+                # conn = Connection(
+                #     server,
+                #     user=self.credentials.user_principal,
+                #     password=password,
+                #     authentication=NTLM,
+                #     receive_timeout=self.timeout,
+                # )
+                conn = Connection( # debug
                     server,
                     user=self.credentials.user_principal,
                     password=password,
-                    authentication=NTLM,
                     receive_timeout=self.timeout,
                 )
                 # if conn.bind():

--- a/conpass/services/ldap.py
+++ b/conpass/services/ldap.py
@@ -160,10 +160,32 @@ class LdapService:
                     authentication=NTLM,
                     receive_timeout=self.timeout,
                 )
+                # if conn.bind():
+                #     if self.debug and self.console:
+                #         self.console.print(f"[cyan][DEBUG] Non-SSL connection successful to {dc_ip}[/cyan]")
+                #     return conn
+                # return None
+
+                if self.debug and self.console: # debug
+                    self.console.print(
+                        f"[cyan][DEBUG] Attempting non-SSL bind to {dc_ip}[/cyan]"
+                    )
+
                 if conn.bind():
                     if self.debug and self.console:
-                        self.console.print(f"[cyan][DEBUG] Non-SSL connection successful to {dc_ip}[/cyan]")
+                        self.console.print(
+                            f"[cyan][DEBUG] Non-SSL connection successful to {dc_ip}[/cyan]"
+                        )
                     return conn
+
+                if self.debug and self.console:
+                    self.console.print(
+                        f"[red][DEBUG] Non-SSL bind failed to {dc_ip}[/red]"
+                    )
+                    self.console.print(
+                        f"[red][DEBUG] LDAP result: {conn.result}[/red]"
+                    )
+
                 return None
         except Exception as e:
             if self.debug and self.console:

--- a/conpass/services/ldap.py
+++ b/conpass/services/ldap.py
@@ -148,6 +148,7 @@ class LdapService:
                 # Fall back to non-SSL
                 if self.debug and self.console:
                     self.console.print(f"[cyan][DEBUG] SSL failed for {dc_ip} ({type(e).__name__}), trying non-SSL[/cyan]")
+                    f"print{e}"
                 server = self._create_ldap_server(dc_ip, False)
                 conn = Connection(
                     server,

--- a/conpass/services/ldap.py
+++ b/conpass/services/ldap.py
@@ -162,7 +162,7 @@ class LdapService:
                 # )
                 conn = Connection( # debug
                     server,
-                    user=self.credentials.user_principal,
+                    user=f"{self.credentials.username}@{self.credentials.domain}",
                     password=password,
                     receive_timeout=self.timeout,
                 )

--- a/conpass/services/ldap.py
+++ b/conpass/services/ldap.py
@@ -116,6 +116,9 @@ class LdapService:
         Returns:
             Connection object if successful, None otherwise
         """
+
+        print("DEBUG: USING MODIFIED _create_connection") # Debug
+
         # Determine the password to use (cleartext or hash)
         if self.credentials.has_hash:
             # Parse and format hash for LDAP3
@@ -148,7 +151,7 @@ class LdapService:
                 # Fall back to non-SSL
                 if self.debug and self.console:
                     self.console.print(f"[cyan][DEBUG] SSL failed for {dc_ip} ({type(e).__name__}), trying non-SSL[/cyan]")
-                    f"print{e}"
+                    f"print({e})" # Debug
                 server = self._create_ldap_server(dc_ip, False)
                 conn = Connection(
                     server,

--- a/conpass/services/policy.py
+++ b/conpass/services/policy.py
@@ -62,6 +62,11 @@ class PolicyService:
             raise ValueError("Policies not loaded. Call load_policies() first.")
 
         search_filter = "(&(objectClass=user)(!(sAMAccountName=*$)))"
+
+        if user_filter:
+            user_clauses = "".join(f"(sAMAccountName={username})" for username in user_filter)
+            search_filter = ("(&(objectClass=user)" "(!(sAMAccountName=*$))" f"(|{user_clauses}))")
+        
         attributes = [
             'samAccountName',
             'badPwdCount',

--- a/conpass/services/spray.py
+++ b/conpass/services/spray.py
@@ -554,7 +554,15 @@ class SprayOrchestrator:
                 # Update completed count
                 with self.completed_lock:
                     completed = self.completed_count
+
                 progress.update(task, completed=completed)
+
+                # All current work completed and queue is empty
+                if (
+                    self.work_queue.empty()
+                    and completed >= total_tests
+                ):
+                    break
 
                 time.sleep(0.5)
 


### PR DESCRIPTION
When we need to perform password spraying on a limited user dataset, `conpass` still queries all users of the domain. For example, I wanted to spray just two users while the domain had 40k+:

<img width="1727" height="300" alt="conpass-all-users" src="https://github.com/user-attachments/assets/89044f8f-35c0-4fcf-b292-6c327afdbf8f" />

I added a filter, so when a users file is passed it focuses directly on just those users instead:

<img width="1763" height="581" alt="conpass-filtered-users" src="https://github.com/user-attachments/assets/fde900df-a096-4d3c-b8e2-952c1e278125" />