### PR TITLE
fix: exit spray loop when all queued password tests complete

### DIFF
--- a/conpass/services/spray.py
+++ b/conpass/services/spray.py
@@ -554,7 +554,15 @@ class SprayOrchestrator:
                 # Update completed count
                 with self.completed_lock:
                     completed = self.completed_count
+
                 progress.update(task, completed=completed)
+
+                # All current work completed and queue is empty
+                if (
+                    self.work_queue.empty()
+                    and completed >= total_tests
+                ):
+                    break
 
                 time.sleep(0.5)
 


### PR DESCRIPTION
When using a password file, ConPass can remain running after the progress bar reaches 100%. 

This occurs because `_feed_work_queue()` continues monitoring worker threads even after all queued work has been completed. 

This change exits the monitoring loop when the work queue is empty and all scheduled tests have completed, allowing the spray operation to terminate cleanly.